### PR TITLE
Add attribute mapping for class shortname

### DIFF
--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,18 +51,11 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        
-         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
-        // so this conversion is imvalid 
-
-        // $datetime = DateTime::createFromFormat(
-        //     'Y-m-d',
-        //     $date,
-        //     new DateTimeZone('UTC')
-        // );
-
-        $datetime = new DateTime($date);
-        
+        $datetime = DateTime::createFromFormat(
+            'Y-m-d',
+            $date,
+            new DateTimeZone('UTC')
+        );
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,11 +51,18 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        $datetime = DateTime::createFromFormat(
-            'Y-m-d',
-            $date,
-            new DateTimeZone('UTC')
-        );
+        
+         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
+        // so this conversion is imvalid 
+
+        // $datetime = DateTime::createFromFormat(
+        //     'Y-m-d',
+        //     $date,
+        //     new DateTimeZone('UTC')
+        // );
+
+        $datetime = new DateTime($date);
+        
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -114,13 +114,17 @@ class class_entity extends entity implements course_representation {
      * @return  stdClass
      */
     public function get_course_data(): stdClass {
+        $shortname_attribute = get_config('enrol_oneroster', 'shortname_attribute');
+        if (empty($shortname_attribute)) {
+            $shortname_attribute = 'sourcedId';
+        }
         $coursedata = (object) [
             'idnumber' => $this->get('sourcedId'),
             'fullname' => $this->get('title'),
 
             // Note: The courseCode is not guaranteed to be unique.
             // This may need to be adjusted accordingly, or using an admin setting.
-            'shortname' => $this->get('sourcedId'),
+            'shortname' => $this->get($shortname_attribute),
 
             // Valid states are 'active' or 'tobedeleted'.
             'visible' => ($this->get('status') === 'active'),

--- a/classes/local/entities/user.php
+++ b/classes/local/entities/user.php
@@ -27,7 +27,7 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\endpoints\rostering as rostering_endpoint;
 use enrol_oneroster\local\entity;
-use enrol_oneroster\local\interfaces\ user_representation;
+use enrol_oneroster\local\interfaces\user_representation;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use stdClass;
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -530,6 +530,7 @@ EOF;
 
         // Fetch the user representation for this entity.
         $remoteuser = $entity->get_user_data();
+        $remoteuser->mnethostid = $CFG->mnet_localhost_id;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,7 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_attribute_mapping'] = 'Attribute mapping';
 $string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
 $string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,8 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
+$string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';
 $string['settings_testconnection_detail'] = 'You should test your settings to ensure that the connection to the server works as expected.
 This is also used to fetch the list of available schools that should be synchronised.';

--- a/settings.php
+++ b/settings.php
@@ -180,16 +180,18 @@ if ($ADMIN->fulltree) {
         ''
     ));
 
+    $fields = [
+        'sourcedId' => 'sourcedId',
+        'classCode' => 'classCode'
+    ];
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',
             get_string('settings_shortname_attribute', 'enrol_oneroster'),
             get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
             'sourcedId',
-            [
-                'sourcedId' => 'sourcedId',
-                'classCode' => 'classCode'
-            ]
+            $fields
         )
     );
 
@@ -215,16 +217,21 @@ if ($ADMIN->fulltree) {
             -1 => 'notmapped',
         ],
         array_map(function($role) {
-
             return $role->shortname;
         }, get_all_roles(null))
     );
-    $courseroles = array_merge(
-        [
-            -1 => get_string('settings_notmapped', 'enrol_oneroster'),
-        ],
-        role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
-    );
+
+    // important change:use role id instead of role index which may cause a lot of errors 
+    // when administrators are changing sort order.
+    $roles = get_all_roles(\context_course::instance(SITEID));
+    $roleNames = role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true);
+    
+    $courseroles =
+        [ '0' => get_string('settings_notmapped', 'enrol_oneroster') ] +
+        array_combine(
+            array_map(function($v){ return strval($v->id); }, $roles),
+            $roleNames
+        );
 
     // Mapping for the 'student' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'student', $allroles, $courseroles, 'student');

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,19 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(
+        new admin_setting_configselect(
+            'enrol_oneroster/shortname_attribute',
+            get_string('settings_shortname_attribute', 'enrol_oneroster'),
+            get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
+            'sourcedId',
+            [
+                'sourcedId' => 'sourcedId',
+                'classCode' => 'classCode'
+            ]
+        )
+    );
+
 
     // Role mappings for the following One Roster roles:
     // - student;

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,12 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(new admin_setting_heading(
+        'enrol_oneroster/attribute_mapping',
+        get_string('settings_attribute_mapping', 'enrol_oneroster'),
+        ''
+    ));
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-07-21';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-07-21';
+$plugin->release = '2022-09-19';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021012000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2021-01-20';
+$plugin->release = '2022-07-21';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This PR enables the attribute mapping of `class->shortname` by using an admin setting. Available attributes are `['sourcedId', 'classCode']`. `class_entity` uses this setting to return a configurable `shortname` before synchronizing course.

![image](https://user-images.githubusercontent.com/9191768/180074853-442ddad9-6563-481f-ac08-bb8aea3c2f71.png)
