### PR TITLE
Enable caching of OneRoster classes for validatiing updates

### DIFF
--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,18 +51,11 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        
-         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
-        // so this conversion is imvalid 
-
-        // $datetime = DateTime::createFromFormat(
-        //     'Y-m-d',
-        //     $date,
-        //     new DateTimeZone('UTC')
-        // );
-
-        $datetime = new DateTime($date);
-        
+        $datetime = DateTime::createFromFormat(
+            'Y-m-d',
+            $date,
+            new DateTimeZone('UTC')
+        );
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,11 +51,18 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        $datetime = DateTime::createFromFormat(
-            'Y-m-d',
-            $date,
-            new DateTimeZone('UTC')
-        );
+        
+         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
+        // so this conversion is imvalid 
+
+        // $datetime = DateTime::createFromFormat(
+        //     'Y-m-d',
+        //     $date,
+        //     new DateTimeZone('UTC')
+        // );
+
+        $datetime = new DateTime($date);
+        
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -114,13 +114,17 @@ class class_entity extends entity implements course_representation {
      * @return  stdClass
      */
     public function get_course_data(): stdClass {
+        $shortname_attribute = get_config('enrol_oneroster', 'shortname_attribute');
+        if (empty($shortname_attribute)) {
+            $shortname_attribute = 'sourcedId';
+        }
         $coursedata = (object) [
             'idnumber' => $this->get('sourcedId'),
             'fullname' => $this->get('title'),
 
             // Note: The courseCode is not guaranteed to be unique.
             // This may need to be adjusted accordingly, or using an admin setting.
-            'shortname' => $this->get('sourcedId'),
+            'shortname' => $this->get($shortname_attribute),
 
             // Valid states are 'active' or 'tobedeleted'.
             'visible' => ($this->get('status') === 'active'),

--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -27,6 +27,8 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\converter;
 use enrol_oneroster\local\collections\enrollments as enrollments_collection;
+use enrol_oneroster\local\collections\students_for_class as students_collection;
+use enrol_oneroster\local\collections\teachers_for_class as teachers_collection;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use enrol_oneroster\local\interfaces\course_representation;
 use enrol_oneroster\local\interfaces\user_representation;
@@ -204,5 +206,49 @@ class class_entity extends entity implements course_representation {
 
         $filter->add_filter('class', $this->get('sourcedId'));
         return $this->container->get_collection_factory()->get_enrollments($params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all students in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  students_collection
+     */
+    public function get_students(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): students_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_students_for_class($class, $params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all teachers in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  teachers_collection
+     */
+    public function get_teachers(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): teachers_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_teachers_for_class($class, $params, $filter, $recordfilter);
     }
 }

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -90,10 +90,24 @@ class enrollment extends entity implements enrollment_representation {
     public function get_user_entity(): ?user {
         // Fetch the user details.
         $userref = $this->get('user');
-
-        // The parentref is a guidref and should contain both the sourcedId and the type.
-        // It also contains an href, but this is not reliable and cannot be used.
-        return $this->container->get_entity_factory()->fetch_user_by_id($userref->sourcedId);
+        // if user is null
+        if ($userref == null) {
+            // do nothing and exit
+            return null;
+        }
+        // check if $userref is a string
+        // important note: this condition is invalid because user must be an object reference 
+        // and may throw an exception
+        // 
+        if (is_string($userref)) {
+            // try to handle string
+            return $this->container->get_entity_factory()->fetch_user_by_id($userref);    
+        }
+        // otherwise use sourcedId to fetch user
+        if (is_string($userref->sourcedId)) {
+            return $this->container->get_entity_factory()->fetch_user_by_id($userref->sourcedId);
+        }
+        return null;
     }
 
     /**

--- a/classes/local/entities/user.php
+++ b/classes/local/entities/user.php
@@ -27,7 +27,7 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\endpoints\rostering as rostering_endpoint;
 use enrol_oneroster\local\entity;
-use enrol_oneroster\local\interfaces\ user_representation;
+use enrol_oneroster\local\interfaces\user_representation;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use stdClass;
 

--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -77,4 +77,10 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function get_enrolment_cache(): cache;
+    /**
+     * Purge entity cache.
+     *
+     * @return  cache
+     */
+    abstract public function purge_cache();
 }

--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -83,4 +83,6 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function purge_cache();
+
+    abstract public function get_class_snapshot_cache(): cache;
 }

--- a/classes/local/factories/entity_factory.php
+++ b/classes/local/factories/entity_factory.php
@@ -73,6 +73,7 @@ class entity_factory extends abstract_factory implements entity_factory_interfac
      * @return  stdClass|null The data stored in the cache
      */
     protected function fetch_from_cache(string $entitytype, string $id, ?filter $filter = null): ?stdClass {
+        
         if ($filter !== null) {
             // It is not possible to use the cache when a filter is applied.
             return null;

--- a/classes/local/interfaces/rostering_client.php
+++ b/classes/local/interfaces/rostering_client.php
@@ -52,4 +52,5 @@ interface rostering_client {
      * @return  array
      */
     public function fetch_organisation_list(): Iterable;
+    
 }

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -191,6 +191,12 @@ trait oneroster_client {
      */
     public function synchronise(?int $onlysincetime = null): void {
         if (class_implements($this, rostering_client::class)) {
+            $caching = get_config('enrol_oneroster', 'oneroster_caching');
+            // if caching is disabled, purge the cache before start
+            if ($caching != '1') {
+                // purge cache and let process to create new cache items
+                $this->get_container()->get_cache_factory()->purge_cache();
+            }
             $this->sync_roster($onlysincetime);
         }
     }

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -190,6 +190,9 @@ trait oneroster_client {
      * @param   int $onlysincetime
      */
     public function synchronise(?int $onlysincetime = null): void {
+        global $CFG;
+        // set debug mode
+        $CFG->debugdeveloper = FALSE;
         if (class_implements($this, rostering_client::class)) {
             $caching = get_config('enrol_oneroster', 'oneroster_caching');
             // if caching is disabled, purge the cache before start

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -89,4 +89,17 @@ class cache_factory extends parent_cache_factory {
     public function get_enrolment_cache(): cache {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
+
+    /**
+     * Purge the cache.
+     */
+    public function purge_cache() {       
+        $this->get_org_cache()->purge();
+        $this->get_academic_session_cache()->purge();
+        $this->get_class_cache()->purge();
+        $this->get_course_cache()->purge();
+        $this->get_user_cache()->purge();
+        $this->get_enrolment_cache()->purge();
+    }
+
 }

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -90,6 +90,10 @@ class cache_factory extends parent_cache_factory {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
 
+    public function get_class_snapshot_cache(): cache {
+        return cache::make('enrol_oneroster', 'v1p1_remote_class_snapshots');
+    }
+
     /**
      * Purge the cache.
      */
@@ -100,6 +104,7 @@ class cache_factory extends parent_cache_factory {
         $this->get_course_cache()->purge();
         $this->get_user_cache()->purge();
         $this->get_enrolment_cache()->purge();
+        $this->get_class_snapshot_cache()->purge();
     }
 
 }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -530,6 +530,7 @@ EOF;
 
         // Fetch the user representation for this entity.
         $remoteuser = $entity->get_user_data();
+        $remoteuser->mnethostid = $CFG->mnet_localhost_id;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -666,8 +666,10 @@ EOF;
 
         // See whether this user is an agent for any other user.
         // Note: This is only applied for students as per section 4.1.2 of the specification.
-        $this->sync_user_agents($entity, $localuser);
-
+        $syncagents = get_config('enrol_oneroster', 'oneroster_sync_agents');
+        if ($syncagents) {
+            $this->sync_user_agents($entity, $localuser);
+        }
         return $localuser;
     }
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -595,9 +595,14 @@ EOF;
      */
     protected function update_existing_user(user_representation $entity, stdClass $remoteuser): stdClass {
         global $DB;
-
-        $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
-
+        // try to get user mapping
+        $mapping = $this->get_user_mapping($remoteuser->idnumber);
+        if ($mapping) {
+            $localuser = $DB->get_record('user', ['id' => $mapping]);
+        } else {
+            // No mapping found, try to get user by idnumber
+            $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
+        }
         // The user exists, user_update_user works on user 'id', so fill that in.
         $remoteuser->id = $localuser->id;
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -711,10 +711,10 @@ EOF;
 
         // No user with the same idnumber, or a mapped idnumber.
         // Create a new user.
-        $this->get_trace()->output(sprintf("Creating new user %s (%s)",
-            $remoteuser->username,
-            $remoteuser->idnumber
-        ), 5);
+        // $this->get_trace()->output(sprintf("Creating new user %s (%s)",
+        //     $remoteuser->username,
+        //     $remoteuser->idnumber
+        // ), 5);
 
         $localuserid = user_create_user($remoteuser);
         if ($localuserid == FALSE) {
@@ -959,13 +959,13 @@ EOF;
                 $this->add_metric('enrollment', 'update');
             }
         } else {
-            $this->get_trace()->output(sprintf(
-                "Enroling user %s into %s from %d to %d",
-                $userentity->get('identifier'),
-                $instance->courseid,
-                $enroldata->timestart,
-                $enroldata->timeend
-            ), 5);
+            // $this->get_trace()->output(sprintf(
+            //     "Enroling user %s into %s from %d to %d",
+            //     $userentity->get('identifier'),
+            //     $instance->courseid,
+            //     $enroldata->timestart,
+            //     $enroldata->timeend
+            // ), 5);
             $this->get_plugin_instance()->enrol_user(
                 $instance,
                 $moodleuserid,

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -695,6 +695,11 @@ EOF;
             }
             // finally create user mapping
             $this->create_user_mapping($user, $remoteuser->idnumber);
+            // if idnumber is not empty and different from remoteuser idnumber
+            if ($user->idnumber != $remoteuser->idnumber) {
+                // create a new user mapping (an in-memory mapping)
+                $this->usermappings[$remoteuser->idnumber] = $user->id;
+            }
             if ($CFG->debugdeveloper) {
                 $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
                     $remoteuser->username,
@@ -737,7 +742,6 @@ EOF;
             $localuser = $DB->get_record('user', ['id' => $mapping]);
         } else {
             // validate the given idnumber (it should be unique across the system)
-
             // No mapping found, try to get user by idnumber
             $users = $DB->get_records('user', [
                 'idnumber' => $remoteuser->idnumber

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -185,9 +185,9 @@ trait oneroster_client {
                 catch (Exception $e) {
                     $this->get_trace()->output("Error synchronising school '{$schoolidtosync} {$school_name}'", 2);
                     $this->get_trace()->output("Error '{$e->getMessage()}'", 2);
-                    if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                        $this->get_trace()->output($e->getTraceAsString(), 3);
-                    }   
+                    // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                    //     $this->get_trace()->output($e->getTraceAsString(), 3);
+                    // }   
                 }
             } else {
                 $this->get_trace()->output("Organisation with sourcedId '{$schoolidtosync}' is not a school. Skipping.", 3);
@@ -354,9 +354,9 @@ EOF;
                         $error_count++;
                         $this->get_trace()->output("Error synchronising teacher '{$teacher->get('username')}'", 4);
                         $this->get_trace()->output("Error '{$e->getMessage()}'", 4);
-                        if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                            $this->get_trace()->output($e->getTraceAsString(), 4);
-                        }
+                        // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                        //     $this->get_trace()->output($e->getTraceAsString(), 4);
+                        // }
                     }
                 }
 
@@ -391,9 +391,9 @@ EOF;
                         $error_count++;
                         $this->get_trace()->output("Error synchronising student '{$student->get('username')}'", 4);
                         $this->get_trace()->output("Error '{$e->getMessage()}'", 4);
-                        if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                            $this->get_trace()->output($e->getTraceAsString(), 4);
-                        }
+                        // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                        //     $this->get_trace()->output($e->getTraceAsString(), 4);
+                        // }
                     }
                 }
 
@@ -700,12 +700,12 @@ EOF;
                 // create a new user mapping (an in-memory mapping)
                 $this->usermappings[$remoteuser->idnumber] = $user->id;
             }
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
-                    $remoteuser->username,
-                    $user->idnumber
-                ), 5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
+            //         $remoteuser->username,
+            //         $user->idnumber
+            //     ), 5);
+            // }
             return $user;
         }
 
@@ -755,12 +755,12 @@ EOF;
         $remoteuser->id = $localuser->id;
 
         if ($localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
-                    $localuser->username,
-                    $localuser->id
-                ), 5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
+            //         $localuser->username,
+            //         $localuser->id
+            //     ), 5);
+            // }
             return $localuser;
         }
 
@@ -988,13 +988,13 @@ EOF;
             if ($ras) {
                 return;
             }
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(
-                    "Updating role assignment for " .
-                    $userentity->get('identifier') .
-                    " in {$instance->courseid}",
-                    5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(
+            //         "Updating role assignment for " .
+            //         $userentity->get('identifier') .
+            //         " in {$instance->courseid}",
+            //         5);
+            // }
             // asign role
             role_assign($moodleroleid, $moodleuserid, $context->id, $component, $itemid);
         }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -904,7 +904,7 @@ EOF;
                     $enroldata->timestart,
                     $enroldata->timeend
                 );
-                $this->add_metric('enrollment', 'delete');
+                $this->add_metric('enrollment', 'update');
             }
         } else {
             $this->get_trace()->output(sprintf(
@@ -925,6 +925,26 @@ EOF;
             );
             $this->add_metric('enrollment', 'create');
         }
+
+        if ($moodleroleid) {
+            // get context
+            $context = \context_course::instance($instance->courseid, TRUE);
+            $component = 'enrol_'.$instance->enrol;
+            $itemid = $instance->id;
+            // check if role assignment already exists
+            $ras = $DB->get_records('role_assignments', array('roleid'=>$moodleroleid, 'contextid'=>$context->id, 'userid'=>$moodleuserid, 'component'=>$component, 'itemid'=>$itemid), 'id');
+            if ($ras) {
+                return;
+            }
+            $this->get_trace()->output(
+                "Updating role assignment for " .
+                $userentity->get('identifier') .
+                " in {$instance->courseid}",
+                4);
+            // asign role
+            role_assign($moodleroleid, $moodleuserid, $context->id, $component, $itemid);
+        }
+
     }
 
     /**

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -718,10 +718,20 @@ EOF;
 
         $localuserid = user_create_user($remoteuser);
         if ($localuserid == FALSE) {
+            $this->get_trace()->output(sprintf("Failed to create new user %s (%s)",
+                $remoteuser->username,
+                $remoteuser->idnumber
+            ), 5);
             throw new Exception("Failed to create new user");
         }
         $this->add_metric('user', 'create');
         $localuser = core_user::get_user($localuserid);
+        if ($localuserid == FALSE) {
+            $this->get_trace()->output(sprintf("Failed to get new user with id %s",
+                $localuserid
+            ), 5);
+            throw new Exception("Failed to get new user");
+        }
         $this->create_user_mapping($localuser, $remoteuser->idnumber);
 
         return $localuser;

--- a/db/caches.php
+++ b/db/caches.php
@@ -68,4 +68,11 @@ $definitions = [
         'staticacceleration' => true,
         'staticaccelerationsize' => 1000,
     ],
+    'v1p1_remote_class_snapshots' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => false,
+        'simpledata' => true,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 1000,
+    ],
 ];

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,7 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_attribute_mapping'] = 'Attribute mapping';
 $string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
 $string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,8 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
+$string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';
 $string['settings_testconnection_detail'] = 'You should test your settings to ensure that the connection to the server works as expected.
 This is also used to fetch the list of available schools that should be synchronised.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -80,3 +80,5 @@ $string['test_oneroster_connection'] = 'Test One Roster Connection';
 $string['fullsync'] = 'Full sync of One Roster';
 $string['settings_datasync_academic_session'] = 'Select academic session';
 $string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';
+$string['settings_connection_oneroster_caching'] = 'Caching';
+$string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -82,3 +82,5 @@ $string['settings_datasync_academic_session'] = 'Select academic session';
 $string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';
 $string['settings_connection_oneroster_caching'] = 'Caching';
 $string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';
+$string['settings_connection_oneroster_sync_agents'] = 'User Agents';
+$string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -78,3 +78,5 @@ This is also used to fetch the list of available schools that should be synchron
 $string['settings_testconnection_link'] = 'Test connection';
 $string['test_oneroster_connection'] = 'Test One Roster Connection';
 $string['fullsync'] = 'Full sync of One Roster';
+$string['settings_datasync_academic_session'] = 'Select academic session';
+$string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';

--- a/settings.php
+++ b/settings.php
@@ -180,16 +180,18 @@ if ($ADMIN->fulltree) {
         ''
     ));
 
+    $fields = [
+        'sourcedId' => 'sourcedId',
+        'classCode' => 'classCode'
+    ];
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',
             get_string('settings_shortname_attribute', 'enrol_oneroster'),
             get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
             'sourcedId',
-            [
-                'sourcedId' => 'sourcedId',
-                'classCode' => 'classCode'
-            ]
+            $fields
         )
     );
 
@@ -215,16 +217,21 @@ if ($ADMIN->fulltree) {
             -1 => 'notmapped',
         ],
         array_map(function($role) {
-
             return $role->shortname;
         }, get_all_roles(null))
     );
-    $courseroles = array_merge(
-        [
-            -1 => get_string('settings_notmapped', 'enrol_oneroster'),
-        ],
-        role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
-    );
+
+    // important change:use role id instead of role index which may cause a lot of errors 
+    // when administrators are changing sort order.
+    $roles = get_all_roles(\context_course::instance(SITEID));
+    $roleNames = role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true);
+    
+    $courseroles =
+        [ '0' => get_string('settings_notmapped', 'enrol_oneroster') ] +
+        array_combine(
+            array_map(function($v){ return strval($v->id); }, $roles),
+            $roleNames
+        );
 
     // Mapping for the 'student' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'student', $allroles, $courseroles, 'student');

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,19 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(
+        new admin_setting_configselect(
+            'enrol_oneroster/shortname_attribute',
+            get_string('settings_shortname_attribute', 'enrol_oneroster'),
+            get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
+            'sourcedId',
+            [
+                'sourcedId' => 'sourcedId',
+                'classCode' => 'classCode'
+            ]
+        )
+    );
+
 
     // Role mappings for the following One Roster roles:
     // - student;

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,12 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(new admin_setting_heading(
+        'enrol_oneroster/attribute_mapping',
+        get_string('settings_attribute_mapping', 'enrol_oneroster'),
+        ''
+    ));
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',

--- a/settings.php
+++ b/settings.php
@@ -118,6 +118,16 @@ if ($ADMIN->fulltree) {
         4
     ));
 
+    $yesno = array(get_string('no'), get_string('yes'));
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_caching',
+        get_string('settings_connection_oneroster_caching', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_caching_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
+
     // Test connection.
     $settings->add(new admin_setting_heading(
         'enrol_oneroster/testconnection',

--- a/settings.php
+++ b/settings.php
@@ -264,6 +264,15 @@ if ($ADMIN->fulltree) {
     // Mapping for the 'relative' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'relative', $allroles, $courseroles);
 
+    $yesno = array(get_string('no'), get_string('yes'));
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_sync_agents',
+        get_string('settings_connection_oneroster_sync_agents', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_sync_agents_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
     // Data to synchronise:
     // - Fetch list of available schools button; and
     // - List of schools to sync.

--- a/settings.php
+++ b/settings.php
@@ -281,6 +281,24 @@ if ($ADMIN->fulltree) {
         $availableschools
     ));
 
+
+    $academic_sessions = [];
+    if ($academic_sessions_json = get_config('enrol_oneroster', 'academic_sessions')) {
+        $academic_sessions = (array) json_decode($academic_sessions_json);
+    }
+
+    if (empty($academic_sessions_json)) {
+        $academic_sessions[''] = get_string('none', 'admin');
+    }
+
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/datasync_academic_session',
+        get_string('settings_datasync_academic_session', 'enrol_oneroster'),
+        get_string('settings_datasync_academic_session_desc', 'enrol_oneroster'),
+        [],
+        $academic_sessions
+    ));
+
 }
 
 if ($hassiteconfig) {

--- a/settings.php
+++ b/settings.php
@@ -295,7 +295,7 @@ if ($ADMIN->fulltree) {
         'enrol_oneroster/datasync_academic_session',
         get_string('settings_datasync_academic_session', 'enrol_oneroster'),
         get_string('settings_datasync_academic_session_desc', 'enrol_oneroster'),
-        [],
+        '',
         $academic_sessions
     ));
 

--- a/testconnection.php
+++ b/testconnection.php
@@ -67,10 +67,19 @@ $client->authenticate();
 $foundorgs = [];
 $organisations = $client->fetch_organisation_list();
 foreach ($organisations as $org) {
-    $foundorgs[$org->get('sourcedId')] = $org->get('name');
+    $foundorgs[$org->get('sourcedId')] = $org->get('name') . ' (' . $org->get('identifier') . ')' ;
 }
-
 set_config('availableschools', json_encode($foundorgs), 'enrol_oneroster');
+
+$academic_sessions = $client->fetch_academic_session_list();
+$found_sessions = [];
+foreach ($academic_sessions as $academic_session) {
+    // get only semesters
+    if ($academic_session->get('type') == 'semester') {
+        $found_sessions[$academic_session->get('sourcedId')] = $academic_session->get('title');
+    }
+}
+set_config('academic_sessions', json_encode($found_sessions), 'enrol_oneroster');
 
 redirect(
     $returnurl,

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-07-21';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-07-21';
+$plugin->release = '2022-09-19';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021012000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2021-01-20';
+$plugin->release = '2022-07-21';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092002;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092601;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-20';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101403;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102001;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-14';
+$plugin->release = '2024-10-20';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101401;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101402;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-02';
+$plugin->release = '2024-10-14';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024041000;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024041000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091700;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-09-19';
+$plugin->release = '2024-09-17';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092601;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-20';
+$plugin->release = '2024-09-27';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-17';
+$plugin->release = '2024-09-19';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092002;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-19';
+$plugin->release = '2024-09-20';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-17';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102001;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102305;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-20';
+$plugin->release = '2024-10-23';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091700;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-17';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024100201;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-27';
+$plugin->release = '2024-10-02';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101402;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101403;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-10-14';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024100201;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101401;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-10-02';


### PR DESCRIPTION
This PR implements a new cache storage for OneRoster classes. This storage holds information about classes being synced. The synchronization process searches cache items in order to identify if a class has been modified after last synced.