### PR TITLE
Accept multiple academic session hooks

### DIFF
--- a/classes/external/class_webhook.php
+++ b/classes/external/class_webhook.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace enrol_oneroster\external;
+use external_api;
+use external_function_parameters;
+use external_single_structure;
+use external_multiple_structure;
+use external_value;
+use external_warnings;
+
+use enrol_oneroster\client_helper;
+
+class class_webhook extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters(
+            [
+                'classCode' => new external_value(
+                        PARAM_TEXT,
+                        'OneRoster class code',
+                        VALUE_REQUIRED
+                ),
+                'school' => new external_value(
+                        PARAM_TEXT,
+                        'OneRoster school code',
+                        VALUE_OPTIONAL
+                    )
+        ]
+        );
+    }
+
+    public static function execute($classCode, $school = null): array {
+        global $DB;
+
+        $result = true;
+        $warnings = [];
+
+        // get oneroster config
+        $config = get_config('enrol_oneroster');
+        // get client
+        $client = client_helper::get_client(
+            $config->oauth_version,
+            $config->oneroster_version,
+            $config->token_url,
+            $config->root_url,
+            $config->clientid,
+            $config->secret
+        );
+        // create extra filter for the specific class
+        $filter = [
+            'classCode' => $classCode
+        ];
+        if ($school) {
+            $filter['school'] = $school;
+        }
+        // authenticate client
+        try {
+            $client->authenticate();
+            $client->synchronise(null, $filter);
+        } catch (\Exception $e) {
+            $result = false;
+            $warnings[] = [
+                'warningcode' => $e->getCode(),
+                'message' => $e->getMessage()
+            ];
+        }
+        
+        return [
+            'result' => $result,
+            'warnings' => $warnings
+        ];
+    }
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure([
+            'result' => new external_value(PARAM_BOOL, 'The processing result'),
+            'warnings' => new external_warnings()
+        ]);
+    }
+}

--- a/classes/external/class_webhook.php
+++ b/classes/external/class_webhook.php
@@ -14,7 +14,7 @@ class class_webhook extends external_api {
     public static function execute_parameters(): external_function_parameters {
         return new external_function_parameters(
             [
-                'classCode' => new external_value(
+                'sourcedId' => new external_value(
                         PARAM_TEXT,
                         'OneRoster class code',
                         VALUE_REQUIRED
@@ -28,7 +28,7 @@ class class_webhook extends external_api {
         );
     }
 
-    public static function execute($classCode, $school = null): array {
+    public static function execute($sourcedId, $school = null): array {
         global $DB;
 
         $result = true;
@@ -47,7 +47,7 @@ class class_webhook extends external_api {
         );
         // create extra filter for the specific class
         $filter = [
-            'classCode' => $classCode
+            'sourcedId' => $sourcedId
         ];
         if ($school) {
             $filter['school'] = $school;

--- a/classes/external/class_webhook.php
+++ b/classes/external/class_webhook.php
@@ -1,12 +1,12 @@
 <?php
 
 namespace enrol_oneroster\external;
-use external_api;
-use external_function_parameters;
-use external_single_structure;
-use external_multiple_structure;
-use external_value;
-use external_warnings;
+use \core_external\external_api as external_api;
+use \core_external\external_function_parameters as external_function_parameters;
+use \core_external\external_single_structure as external_single_structure;
+use \core_external\external_multiple_structure as external_multiple_structure;
+use \core_external\external_value as external_value;
+use \core_external\external_warnings as external_warnings;
 
 use enrol_oneroster\client_helper;
 

--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,18 +51,11 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        
-         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
-        // so this conversion is imvalid 
-
-        // $datetime = DateTime::createFromFormat(
-        //     'Y-m-d',
-        //     $date,
-        //     new DateTimeZone('UTC')
-        // );
-
-        $datetime = new DateTime($date);
-        
+        $datetime = DateTime::createFromFormat(
+            'Y-m-d',
+            $date,
+            new DateTimeZone('UTC')
+        );
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,11 +51,18 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        $datetime = DateTime::createFromFormat(
-            'Y-m-d',
-            $date,
-            new DateTimeZone('UTC')
-        );
+        
+         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
+        // so this conversion is imvalid 
+
+        // $datetime = DateTime::createFromFormat(
+        //     'Y-m-d',
+        //     $date,
+        //     new DateTimeZone('UTC')
+        // );
+
+        $datetime = new DateTime($date);
+        
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -114,13 +114,17 @@ class class_entity extends entity implements course_representation {
      * @return  stdClass
      */
     public function get_course_data(): stdClass {
+        $shortname_attribute = get_config('enrol_oneroster', 'shortname_attribute');
+        if (empty($shortname_attribute)) {
+            $shortname_attribute = 'sourcedId';
+        }
         $coursedata = (object) [
             'idnumber' => $this->get('sourcedId'),
             'fullname' => $this->get('title'),
 
             // Note: The courseCode is not guaranteed to be unique.
             // This may need to be adjusted accordingly, or using an admin setting.
-            'shortname' => $this->get('sourcedId'),
+            'shortname' => $this->get($shortname_attribute),
 
             // Valid states are 'active' or 'tobedeleted'.
             'visible' => ($this->get('status') === 'active'),

--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -27,6 +27,8 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\converter;
 use enrol_oneroster\local\collections\enrollments as enrollments_collection;
+use enrol_oneroster\local\collections\students_for_class as students_collection;
+use enrol_oneroster\local\collections\teachers_for_class as teachers_collection;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use enrol_oneroster\local\interfaces\course_representation;
 use enrol_oneroster\local\interfaces\user_representation;
@@ -204,5 +206,49 @@ class class_entity extends entity implements course_representation {
 
         $filter->add_filter('class', $this->get('sourcedId'));
         return $this->container->get_collection_factory()->get_enrollments($params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all students in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  students_collection
+     */
+    public function get_students(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): students_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_students_for_class($class, $params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all teachers in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  teachers_collection
+     */
+    public function get_teachers(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): teachers_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_teachers_for_class($class, $params, $filter, $recordfilter);
     }
 }

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -175,4 +175,16 @@ class enrollment extends entity implements enrollment_representation {
         // A user is enrolled in a class, which we use as a representation of a Moodle course.
         return $this->get_class_entity();
     }
+
+    public function get_enrolment_term() {
+        $metadata = $this->get('metadata');
+        if (empty($metadata)) {
+            return null;
+        }
+        if (is_string($metadata->term)) {
+            return $this->container->get_entity_factory()->fetch_term_by_id($metadata->term);
+        }
+        return null;
+    }
+
 }

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -90,10 +90,24 @@ class enrollment extends entity implements enrollment_representation {
     public function get_user_entity(): ?user {
         // Fetch the user details.
         $userref = $this->get('user');
-
-        // The parentref is a guidref and should contain both the sourcedId and the type.
-        // It also contains an href, but this is not reliable and cannot be used.
-        return $this->container->get_entity_factory()->fetch_user_by_id($userref->sourcedId);
+        // if user is null
+        if ($userref == null) {
+            // do nothing and exit
+            return null;
+        }
+        // check if $userref is a string
+        // important note: this condition is invalid because user must be an object reference 
+        // and may throw an exception
+        // 
+        if (is_string($userref)) {
+            // try to handle string
+            return $this->container->get_entity_factory()->fetch_user_by_id($userref);    
+        }
+        // otherwise use sourcedId to fetch user
+        if (is_string($userref->sourcedId)) {
+            return $this->container->get_entity_factory()->fetch_user_by_id($userref->sourcedId);
+        }
+        return null;
     }
 
     /**

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -182,7 +182,7 @@ class enrollment extends entity implements enrollment_representation {
             return null;
         }
         if (is_string($metadata->term)) {
-            return $this->container->get_entity_factory()->fetch_term_by_id($metadata->term);
+            return $this->container->get_entity_factory()->fetch_academic_session_by_id($metadata->term);
         }
         return null;
     }

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -187,4 +187,17 @@ class enrollment extends entity implements enrollment_representation {
         return null;
     }
 
+    public function get_enrolment_terms() {
+        $metadata = $this->get('metadata');
+        if (empty($metadata)) {
+            return [];
+        }
+        if (is_array($metadata->terms)) {
+            return array_map(function($term) {
+                return $this->container->get_entity_factory()->fetch_academic_session_by_id($term);
+            }, $metadata->terms);
+        }
+        return [];
+    }
+
 }

--- a/classes/local/entities/user.php
+++ b/classes/local/entities/user.php
@@ -27,7 +27,7 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\endpoints\rostering as rostering_endpoint;
 use enrol_oneroster\local\entity;
-use enrol_oneroster\local\interfaces\ user_representation;
+use enrol_oneroster\local\interfaces\user_representation;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use stdClass;
 

--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -77,4 +77,10 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function get_enrolment_cache(): cache;
+    /**
+     * Purge entity cache.
+     *
+     * @return  cache
+     */
+    abstract public function purge_cache();
 }

--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -83,4 +83,6 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function purge_cache();
+
+    abstract public function get_class_snapshot_cache(): cache;
 }

--- a/classes/local/factories/entity_factory.php
+++ b/classes/local/factories/entity_factory.php
@@ -73,6 +73,7 @@ class entity_factory extends abstract_factory implements entity_factory_interfac
      * @return  stdClass|null The data stored in the cache
      */
     protected function fetch_from_cache(string $entitytype, string $id, ?filter $filter = null): ?stdClass {
+        
         if ($filter !== null) {
             // It is not possible to use the cache when a filter is applied.
             return null;

--- a/classes/local/interfaces/client.php
+++ b/classes/local/interfaces/client.php
@@ -74,7 +74,7 @@ interface client {
      *
      * @param   int $onlysincetime
      */
-    public function synchronise(?int $onlysincetime = null): void;
+    public function synchronise(?int $onlysincetime = null, ?array $filter = null): void;
 
     /**
      * Authenticate against the One Roster endpoint as required.

--- a/classes/local/interfaces/enrollment_representation.php
+++ b/classes/local/interfaces/enrollment_representation.php
@@ -57,4 +57,11 @@ interface enrollment_representation {
      * @return  course_representation
      */
     public function get_course_representation(): course_representation;
+
+    /**
+     * Get the term of the enrollment, if available.
+     *
+     * @return  stdClass
+     */
+    public function get_enrolment_term();
 }

--- a/classes/local/interfaces/enrollment_representation.php
+++ b/classes/local/interfaces/enrollment_representation.php
@@ -64,4 +64,11 @@ interface enrollment_representation {
      * @return  stdClass
      */
     public function get_enrolment_term();
+
+    /**
+     * Get a collection of terms associated with the enrollment.
+     *
+     * @return  stdClass[]
+     */
+    public function get_enrolment_terms();
 }

--- a/classes/local/interfaces/rostering_client.php
+++ b/classes/local/interfaces/rostering_client.php
@@ -35,7 +35,7 @@ interface rostering_client {
     /**
      * Get the rostering endpoint for this version of the API.
      *
-     * @return rostering
+     * @return rostering_endpoint
      */
     public function get_rostering_endpoint(): rostering_endpoint;
 
@@ -44,7 +44,7 @@ interface rostering_client {
      *
      * @param   int $onlysincetime
      */
-    public function sync_roster(?int $onlysincetime = null): void;
+    public function sync_roster(?int $onlysincetime = null, ?array $filter = null): void;
 
     /**
      * Fetch the list of organisations that can be syncronised.

--- a/classes/local/interfaces/rostering_client.php
+++ b/classes/local/interfaces/rostering_client.php
@@ -52,4 +52,5 @@ interface rostering_client {
      * @return  array
      */
     public function fetch_organisation_list(): Iterable;
+    
 }

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -191,6 +191,12 @@ trait oneroster_client {
      */
     public function synchronise(?int $onlysincetime = null): void {
         if (class_implements($this, rostering_client::class)) {
+            $caching = get_config('enrol_oneroster', 'oneroster_caching');
+            // if caching is disabled, purge the cache before start
+            if ($caching != '1') {
+                // purge cache and let process to create new cache items
+                $this->get_container()->get_cache_factory()->purge_cache();
+            }
             $this->sync_roster($onlysincetime);
         }
     }

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -189,7 +189,7 @@ trait oneroster_client {
      *
      * @param   int $onlysincetime
      */
-    public function synchronise(?int $onlysincetime = null): void {
+    public function synchronise(?int $onlysincetime = null, ?array $filter = null): void {
         global $CFG;
         // set debug mode
         $CFG->debugdeveloper = FALSE;
@@ -200,7 +200,7 @@ trait oneroster_client {
                 // purge cache and let process to create new cache items
                 $this->get_container()->get_cache_factory()->purge_cache();
             }
-            $this->sync_roster($onlysincetime);
+            $this->sync_roster($onlysincetime, $filter);
         }
     }
 

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -190,6 +190,9 @@ trait oneroster_client {
      * @param   int $onlysincetime
      */
     public function synchronise(?int $onlysincetime = null): void {
+        global $CFG;
+        // set debug mode
+        $CFG->debugdeveloper = FALSE;
         if (class_implements($this, rostering_client::class)) {
             $caching = get_config('enrol_oneroster', 'oneroster_caching');
             // if caching is disabled, purge the cache before start

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -89,4 +89,17 @@ class cache_factory extends parent_cache_factory {
     public function get_enrolment_cache(): cache {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
+
+    /**
+     * Purge the cache.
+     */
+    public function purge_cache() {       
+        $this->get_org_cache()->purge();
+        $this->get_academic_session_cache()->purge();
+        $this->get_class_cache()->purge();
+        $this->get_course_cache()->purge();
+        $this->get_user_cache()->purge();
+        $this->get_enrolment_cache()->purge();
+    }
+
 }

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -90,6 +90,10 @@ class cache_factory extends parent_cache_factory {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
 
+    public function get_class_snapshot_cache(): cache {
+        return cache::make('enrol_oneroster', 'v1p1_remote_class_snapshots');
+    }
+
     /**
      * Purge the cache.
      */
@@ -100,6 +104,7 @@ class cache_factory extends parent_cache_factory {
         $this->get_course_cache()->purge();
         $this->get_user_cache()->purge();
         $this->get_enrolment_cache()->purge();
+        $this->get_class_snapshot_cache()->purge();
     }
 
 }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -530,6 +530,7 @@ EOF;
 
         // Fetch the user representation for this entity.
         $remoteuser = $entity->get_user_data();
+        $remoteuser->mnethostid = $CFG->mnet_localhost_id;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -666,8 +666,10 @@ EOF;
 
         // See whether this user is an agent for any other user.
         // Note: This is only applied for students as per section 4.1.2 of the specification.
-        $this->sync_user_agents($entity, $localuser);
-
+        $syncagents = get_config('enrol_oneroster', 'oneroster_sync_agents');
+        if ($syncagents) {
+            $this->sync_user_agents($entity, $localuser);
+        }
         return $localuser;
     }
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -595,9 +595,14 @@ EOF;
      */
     protected function update_existing_user(user_representation $entity, stdClass $remoteuser): stdClass {
         global $DB;
-
-        $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
-
+        // try to get user mapping
+        $mapping = $this->get_user_mapping($remoteuser->idnumber);
+        if ($mapping) {
+            $localuser = $DB->get_record('user', ['id' => $mapping]);
+        } else {
+            // No mapping found, try to get user by idnumber
+            $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
+        }
         // The user exists, user_update_user works on user 'id', so fill that in.
         $remoteuser->id = $localuser->id;
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -628,25 +628,23 @@ EOF;
      */
     protected function ensure_course_enrolment_instance_exists(stdClass $course): void {
         global $DB;
-
-        if (array_key_exists($course->idnumber, $this->instances)) {
-            // The entry already exists in the cache.
-            return;
-        }
-
+        // try to get instance
         $instance = $DB->get_record('enrol', [
             'courseid' => $course->id,
             'enrol' => 'oneroster',
         ]);
-
+        // get status based on the visibility of the course
+        $status = $course->visible == false ? 1 : 0;
         if ($instance) {
             // A record exists, add it to the list.
             $this->instances[$course->idnumber] = $instance;
-
+            // enable or disable enrolment instance
+            $this->get_plugin_instance()->update_instance($instance, (object)[ 'status' => $status ]);
+            // and exit
             return;
         }
-
-        $enrolid = $this->get_plugin_instance()->add_instance($course);
+        // add instance
+        $enrolid = $this->get_plugin_instance()->add_instance($course, ['status' => $status ]);
         $this->instances[$course->idnumber] = $DB->get_record('enrol', ['id' => $enrolid]);
     }
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -210,14 +210,15 @@ trait oneroster_client {
         }
         
         $this->get_trace()->output("Completed synchronisation of Rostering information");
-        $this->get_trace()->output(sprintf("Entity\t\tCreate\tUpdate\tDelete"), 1);
+        $this->get_trace()->output(sprintf("Entity\t\tCreate\tUpdate\tExclude\tDelete"), 1);
         foreach ($this->get_metrics() as $thing => $actions) {
             $this->get_trace()->output(
                 sprintf(
-                    "Entity '%s'\t%d\t%d\t%d",
+                    "Entity '%s'\t%d\t%d\t%d\t%d",
                     $thing,
                     $actions['create'],
                     $actions['update'],
+                    $actions['exclude'],
                     $actions['delete']
                 ),
                 1
@@ -376,6 +377,9 @@ EOF;
 
             // update or create class
             $localcourse = $this->update_or_create_course($class);
+            if (!$localcourse) {
+                continue;
+            }
             $this->get_trace()->output(
                 sprintf(
                     "Getting existing enrollments for course '%s' with id %s",
@@ -710,7 +714,7 @@ EOF;
      * @param   course_representation $entity An entity representing a course category
      * @return  stdClass
      */
-    protected function update_or_create_course(course_representation $entity): stdClass {
+    protected function update_or_create_course(course_representation $entity): ?stdClass {
         global $CFG, $DB;
 
         require_once("{$CFG->dirroot}/course/lib.php");
@@ -741,6 +745,22 @@ EOF;
                 $this->add_metric('course', 'update');
             }
         } else {
+            // check if course is inactive
+            $exclude_inactive = get_config('enrol_oneroster', 'oneroster_exclude_inactive');
+            // inactive courses have already marked as invisible (mdl_course.visible = 0)
+            if ($exclude_inactive && $remotecourse->visible == false) {
+                $this->get_trace()->output(
+                    sprintf(
+                        "Excluding course '%s' with id '%s' because it has been marked as inactive.",
+                        $remotecourse->fullname,
+                        $remotecourse->idnumber
+                    ),
+                    5
+                );
+                // do not create course if it is inactive
+                $this->add_metric('course', 'exclude');
+                return null;
+            }
             $localcourse = create_course($remotecourse);
             $this->add_metric('course', 'create');
         }
@@ -1292,6 +1312,7 @@ EOF;
                 'create' => 0,
                 'update' => 0,
                 'delete' => 0,
+                'exclude' => 0,
             ];
         }
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -711,10 +711,10 @@ EOF;
 
         // No user with the same idnumber, or a mapped idnumber.
         // Create a new user.
-        $this->get_trace()->output(sprintf("Creating new user %s (%s)",
-            $remoteuser->username,
-            $remoteuser->idnumber
-        ), 5);
+        // $this->get_trace()->output(sprintf("Creating new user %s (%s)",
+        //     $remoteuser->username,
+        //     $remoteuser->idnumber
+        // ), 5);
 
         $localuserid = user_create_user($remoteuser);
         if ($localuserid == FALSE) {
@@ -959,13 +959,13 @@ EOF;
                 $this->add_metric('enrollment', 'update');
             }
         } else {
-            $this->get_trace()->output(sprintf(
-                "Enroling user %s into %s from %d to %d",
-                $userentity->get('identifier'),
-                $instance->courseid,
-                $enroldata->timestart,
-                $enroldata->timeend
-            ), 5);
+            // $this->get_trace()->output(sprintf(
+            //     "Enroling user %s into %s from %d to %d",
+            //     $userentity->get('identifier'),
+            //     $instance->courseid,
+            //     $enroldata->timestart,
+            //     $enroldata->timeend
+            // ), 5);
             $this->get_plugin_instance()->enrol_user(
                 $instance,
                 $moodleuserid,

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -695,6 +695,11 @@ EOF;
             }
             // finally create user mapping
             $this->create_user_mapping($user, $remoteuser->idnumber);
+            // if idnumber is not empty and different from remoteuser idnumber
+            if ($user->idnumber != $remoteuser->idnumber) {
+                // create a new user mapping (an in-memory mapping)
+                $this->usermappings[$remoteuser->idnumber] = $user->id;
+            }
             if ($CFG->debugdeveloper) {
                 $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
                     $remoteuser->username,
@@ -737,7 +742,6 @@ EOF;
             $localuser = $DB->get_record('user', ['id' => $mapping]);
         } else {
             // validate the given idnumber (it should be unique across the system)
-
             // No mapping found, try to get user by idnumber
             $users = $DB->get_records('user', [
                 'idnumber' => $remoteuser->idnumber

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -185,9 +185,9 @@ trait oneroster_client {
                 catch (Exception $e) {
                     $this->get_trace()->output("Error synchronising school '{$schoolidtosync} {$school_name}'", 2);
                     $this->get_trace()->output("Error '{$e->getMessage()}'", 2);
-                    if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                        $this->get_trace()->output($e->getTraceAsString(), 3);
-                    }   
+                    // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                    //     $this->get_trace()->output($e->getTraceAsString(), 3);
+                    // }   
                 }
             } else {
                 $this->get_trace()->output("Organisation with sourcedId '{$schoolidtosync}' is not a school. Skipping.", 3);
@@ -354,9 +354,9 @@ EOF;
                         $error_count++;
                         $this->get_trace()->output("Error synchronising teacher '{$teacher->get('username')}'", 4);
                         $this->get_trace()->output("Error '{$e->getMessage()}'", 4);
-                        if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                            $this->get_trace()->output($e->getTraceAsString(), 4);
-                        }
+                        // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                        //     $this->get_trace()->output($e->getTraceAsString(), 4);
+                        // }
                     }
                 }
 
@@ -391,9 +391,9 @@ EOF;
                         $error_count++;
                         $this->get_trace()->output("Error synchronising student '{$student->get('username')}'", 4);
                         $this->get_trace()->output("Error '{$e->getMessage()}'", 4);
-                        if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                            $this->get_trace()->output($e->getTraceAsString(), 4);
-                        }
+                        // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
+                        //     $this->get_trace()->output($e->getTraceAsString(), 4);
+                        // }
                     }
                 }
 
@@ -700,12 +700,12 @@ EOF;
                 // create a new user mapping (an in-memory mapping)
                 $this->usermappings[$remoteuser->idnumber] = $user->id;
             }
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
-                    $remoteuser->username,
-                    $user->idnumber
-                ), 5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(sprintf("Skipping update/create of user %s merged into local user %s",
+            //         $remoteuser->username,
+            //         $user->idnumber
+            //     ), 5);
+            // }
             return $user;
         }
 
@@ -755,12 +755,12 @@ EOF;
         $remoteuser->id = $localuser->id;
 
         if ($localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
-                    $localuser->username,
-                    $localuser->id
-                ), 5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
+            //         $localuser->username,
+            //         $localuser->id
+            //     ), 5);
+            // }
             return $localuser;
         }
 
@@ -988,13 +988,13 @@ EOF;
             if ($ras) {
                 return;
             }
-            if ($CFG->debugdeveloper) {
-                $this->get_trace()->output(
-                    "Updating role assignment for " .
-                    $userentity->get('identifier') .
-                    " in {$instance->courseid}",
-                    5);
-            }
+            // if ($CFG->debugdeveloper) {
+            //     $this->get_trace()->output(
+            //         "Updating role assignment for " .
+            //         $userentity->get('identifier') .
+            //         " in {$instance->courseid}",
+            //         5);
+            // }
             // asign role
             role_assign($moodleroleid, $moodleuserid, $context->id, $component, $itemid);
         }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -311,6 +311,9 @@ EOF;
 
         if ($filter) {
             foreach ($filter as $key => $value) {
+                if ($key == 'school') {
+                    continue;
+                }
                 $classfilter->add_filter($key, $value);
             }
         }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -788,6 +788,22 @@ EOF;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 
+        $metadata = $entity->get('metadata');
+        if ($metadata) {
+            $department_map = get_config('enrol_oneroster', 'user_department_map');
+            if (empty($department_map) == FALSE) {
+                if (property_exists($metadata, $department_map)) {
+                    $remoteuser->department = $metadata->{$department_map};
+                }
+            }
+            $institution_map = get_config('enrol_oneroster', 'user_institution_map');
+            if (empty($institution_map) == FALSE) {
+                if (property_exists($metadata, $institution_map)) {
+                    $remoteuser->institution = $metadata->{$institution_map};
+                }
+            }
+        }
+
         if ($this->get_user_mapping($remoteuser->idnumber)) {
             $localuser = $this->update_existing_user($entity, $remoteuser);
         } else {

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -904,7 +904,7 @@ EOF;
                     $enroldata->timestart,
                     $enroldata->timeend
                 );
-                $this->add_metric('enrollment', 'delete');
+                $this->add_metric('enrollment', 'update');
             }
         } else {
             $this->get_trace()->output(sprintf(
@@ -925,6 +925,26 @@ EOF;
             );
             $this->add_metric('enrollment', 'create');
         }
+
+        if ($moodleroleid) {
+            // get context
+            $context = \context_course::instance($instance->courseid, TRUE);
+            $component = 'enrol_'.$instance->enrol;
+            $itemid = $instance->id;
+            // check if role assignment already exists
+            $ras = $DB->get_records('role_assignments', array('roleid'=>$moodleroleid, 'contextid'=>$context->id, 'userid'=>$moodleuserid, 'component'=>$component, 'itemid'=>$itemid), 'id');
+            if ($ras) {
+                return;
+            }
+            $this->get_trace()->output(
+                "Updating role assignment for " .
+                $userentity->get('identifier') .
+                " in {$instance->courseid}",
+                4);
+            // asign role
+            role_assign($moodleroleid, $moodleuserid, $context->id, $component, $itemid);
+        }
+
     }
 
     /**

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -718,10 +718,20 @@ EOF;
 
         $localuserid = user_create_user($remoteuser);
         if ($localuserid == FALSE) {
+            $this->get_trace()->output(sprintf("Failed to create new user %s (%s)",
+                $remoteuser->username,
+                $remoteuser->idnumber
+            ), 5);
             throw new Exception("Failed to create new user");
         }
         $this->add_metric('user', 'create');
         $localuser = core_user::get_user($localuserid);
+        if ($localuserid == FALSE) {
+            $this->get_trace()->output(sprintf("Failed to get new user with id %s",
+                $localuserid
+            ), 5);
+            throw new Exception("Failed to get new user");
+        }
         $this->create_user_mapping($localuser, $remoteuser->idnumber);
 
         return $localuser;

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -150,7 +150,7 @@ trait oneroster_client {
 
         $schoolidstosync = explode(',', get_config('enrol_oneroster', 'datasync_schools'));
         // if filter contains school, only sync that school
-        if (array_key_exists('school', $filter)) {
+        if (is_array($filter) && array_key_exists('school', $filter)) {
             $schoolidstosync = [$filter['school']];
         }
         $countofschools = count($schoolidstosync);

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -334,7 +334,28 @@ EOF;
         // select active academic session
         $academic_session = get_config('enrol_oneroster', 'datasync_academic_session');
         if ($academic_session) {
-            $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+            // get academic session
+            $academic_session_filter = new filter();
+            $academic_session_filter->add_filter('sourcedId', $academic_session, '=');
+            $academic_sessions = $this->get_container()->get_collection_factory()->get_academic_sessions([], $academic_session_filter);
+            foreach ($academic_sessions as $session) {
+                // exit the loop to get session
+                break;
+            }
+            if ($session instanceof academic_session_entity) {
+               // get academic session type
+                $sessiontype = $session->get('type');
+                if ($sessiontype == 'schoolYear') {
+                    // if school year, include semesters (filtering by parent)
+                    $classfilter->add_filter('terms.parent', $session->get('sourcedId'), '=');
+                } else {
+                    // otherwise, filter by the exact term
+                    $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+                }
+            } else {
+                // if no session found, filter by the exact term
+                $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+            }
         }
 
         $this->get_trace()->output("Fetching class data", 3);
@@ -1376,7 +1397,7 @@ EOF;
      */
     public function fetch_academic_session_list(): Iterable {
         return $this->get_container()->get_collection_factory()->get_academic_sessions(array(
-            'sort' => 'schoolYear',
+            'sort' => 'schoolYear,type',
             'orderBy' => 'asc'
         ));
     }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -915,13 +915,17 @@ EOF;
         // The user exists, user_update_user works on user 'id', so fill that in.
         $remoteuser->id = $localuser->id;
 
-        if ($localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
-            // if ($CFG->debugdeveloper) {
-            //     $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
-            //         $localuser->username,
-            //         $localuser->id
-            //     ), 5);
-            // }
+        // a user should be updated if the remote user has been modified after the local user
+        // but sometimes we should update the user even if the remote user has not been modified
+        // for example, if the remote user has a different department or institution than the local user
+        // we should force update the local user
+        $force = FALSE;
+        if ((property_exists($remoteuser, 'department') && $remoteuser->department != $localuser->department) ||
+            (property_exists($remoteuser, 'institution') && $remoteuser->institution != $localuser->institution)) {
+            $force = TRUE;
+        }
+
+        if ($force == FALSE && $localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
             return $localuser;
         }
 

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -52,6 +52,7 @@ use enrol_oneroster\local\entities\org as org_entity;
 use enrol_oneroster\local\entities\school as school_entity;
 use enrol_oneroster\local\entities\user as user_entity;
 use enrol_oneroster\local\entities\term as term_entity;
+use enrol_oneroster\local\entities\academic_session as academic_session_entity;
 use moodle_url;
 use progress_trace;
 use stdClass;
@@ -481,6 +482,20 @@ EOF;
                                 groups_add_member($course_group, $localuserid, 'enrol_oneroster');
                             }
                         }
+                        // get extra enrolment terms
+                        $enrolment_terms = $enrollment->get_enrolment_terms();
+                        foreach ($enrolment_terms as $term) {
+                            // try to find if the current course has a group associated with the term
+                            $course_group = $this->create_course_group_from_term($localcourse, $term);
+                            // get remote user
+                            $userentity = $enrollment->get_user_entity();
+                            // find local user
+                            $localuserid = $this->get_user_mapping_for_user($userentity);
+                            if ($localuserid) {
+                                // add group membership
+                                groups_add_member($course_group, $localuserid, 'enrol_oneroster');
+                            }
+                        }
                     }
                 }
             }
@@ -547,10 +562,10 @@ EOF;
     /**
      * Create course group using the given academic session
      * @param \stdClass $course
-     * @param term_entity $term
+     * @param academic_session_entity $term
      * @return \stdClass
      */
-    protected function create_course_group_from_term(stdClass $course, term_entity $term): stdClass {
+    protected function create_course_group_from_term(stdClass $course, academic_session_entity $term): stdClass {
         global $DB;
         // if course groups are not enabled
         if (!is_array($course->groups)) {

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -730,6 +730,10 @@ EOF;
         ]);
 
         if ($localcourse) {
+            // do not change category and use the existing one
+            if ($localcourse->category) {
+                $remotecourse->category = $localcourse->category;
+            }
             $update = false;
             foreach ((array) $remotecourse as $field => $value) {
                 if ($localcourse->{$field} != $value) {

--- a/db/caches.php
+++ b/db/caches.php
@@ -68,4 +68,11 @@ $definitions = [
         'staticacceleration' => true,
         'staticaccelerationsize' => 1000,
     ],
+    'v1p1_remote_class_snapshots' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => false,
+        'simpledata' => true,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 1000,
+    ],
 ];

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,11 @@
+<?php
+
+$functions = [
+    'oneroster_class_webhook' => [
+        'classname'   => 'enrol_oneroster\external\class_webhook',
+        'description' => 'Wait for OneRoster webhook to sync classes.',
+        'type'        => 'write',
+        'ajax'        => true,
+        'services' => []
+    ],
+];

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,7 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_attribute_mapping'] = 'Attribute mapping';
 $string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
 $string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -69,6 +69,8 @@ $string['settings_rolemapping_student'] = 'One Roster Student';
 $string['settings_rolemapping_student_desc'] = 'A student at a organization.';
 $string['settings_rolemapping_teacher'] = 'One Roster Teacher';
 $string['settings_rolemapping_teacher_desc'] = 'A Teacher at organization.';
+$string['settings_shortname_attribute'] = 'Shortname Attribute Mapper';
+$string['settings_shortname_attribute_desc'] = 'The attribute of a class that is going to be mapped to course short name. The default value is "sourcedId".';
 $string['settings_testconnection'] = 'Test connection';
 $string['settings_testconnection_detail'] = 'You should test your settings to ensure that the connection to the server works as expected.
 This is also used to fetch the list of available schools that should be synchronised.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -80,3 +80,5 @@ $string['test_oneroster_connection'] = 'Test One Roster Connection';
 $string['fullsync'] = 'Full sync of One Roster';
 $string['settings_datasync_academic_session'] = 'Select academic session';
 $string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';
+$string['settings_connection_oneroster_caching'] = 'Caching';
+$string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -88,3 +88,11 @@ $string['settings_connection_oneroster_sync_groups'] = 'Groups';
 $string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';
 $string['settings_connection_oneroster_exclude_inactive'] = 'Exclude inactive courses';
 $string['settings_connection_oneroster_exclude_inactive_desc'] = 'Exclude inactive courses from the synchronization process. This setting will only synchronize courses that are active in the OneRoster API.';
+$string['settings_connection_oneroster_user_metadata'] = 'User metadata';
+$string['settings_connection_oneroster_user_metadata_desc'] = 'Define the metadata of a user that is going to be mapped to the user profile fields in Moodle.';
+$string['settings_connection_oneroster_user_department'] = 'department';
+$string['settings_connection_oneroster_user_department_desc'] = 'Define the attribute of a user that is going to be mapped to the department field in Moodle. e.g. Use field "alternateMatriculationNumber" provided by OneRoster producer and map it to "department" field in Moodle.';
+$string['settings_connection_oneroster_user_institution'] = 'institution';
+$string['settings_connection_oneroster_user_institution_desc'] = 'Define the attribute of a user that is going to be mapped to the institution field in Moodle. e.g. Use field "matriculationNumber" provided by OneRoster producer and map it to "institution" field in Moodle.';
+
+

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -84,3 +84,5 @@ $string['settings_connection_oneroster_caching'] = 'Caching';
 $string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';
 $string['settings_connection_oneroster_sync_agents'] = 'User Agents';
 $string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';
+$string['settings_connection_oneroster_sync_groups'] = 'Groups';
+$string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -82,3 +82,5 @@ $string['settings_datasync_academic_session'] = 'Select academic session';
 $string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';
 $string['settings_connection_oneroster_caching'] = 'Caching';
 $string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';
+$string['settings_connection_oneroster_sync_agents'] = 'User Agents';
+$string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -86,3 +86,5 @@ $string['settings_connection_oneroster_sync_agents'] = 'User Agents';
 $string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';
 $string['settings_connection_oneroster_sync_groups'] = 'Groups';
 $string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';
+$string['settings_connection_oneroster_exclude_inactive'] = 'Exclude inactive courses';
+$string['settings_connection_oneroster_exclude_inactive_desc'] = 'Exclude inactive courses from the synchronization process. This setting will only synchronize courses that are active in the OneRoster API.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -78,3 +78,5 @@ This is also used to fetch the list of available schools that should be synchron
 $string['settings_testconnection_link'] = 'Test connection';
 $string['test_oneroster_connection'] = 'Test One Roster Connection';
 $string['fullsync'] = 'Full sync of One Roster';
+$string['settings_datasync_academic_session'] = 'Select academic session';
+$string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';

--- a/settings.php
+++ b/settings.php
@@ -180,16 +180,18 @@ if ($ADMIN->fulltree) {
         ''
     ));
 
+    $fields = [
+        'sourcedId' => 'sourcedId',
+        'classCode' => 'classCode'
+    ];
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',
             get_string('settings_shortname_attribute', 'enrol_oneroster'),
             get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
             'sourcedId',
-            [
-                'sourcedId' => 'sourcedId',
-                'classCode' => 'classCode'
-            ]
+            $fields
         )
     );
 
@@ -215,16 +217,21 @@ if ($ADMIN->fulltree) {
             -1 => 'notmapped',
         ],
         array_map(function($role) {
-
             return $role->shortname;
         }, get_all_roles(null))
     );
-    $courseroles = array_merge(
-        [
-            -1 => get_string('settings_notmapped', 'enrol_oneroster'),
-        ],
-        role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
-    );
+
+    // important change:use role id instead of role index which may cause a lot of errors 
+    // when administrators are changing sort order.
+    $roles = get_all_roles(\context_course::instance(SITEID));
+    $roleNames = role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true);
+    
+    $courseroles =
+        [ '0' => get_string('settings_notmapped', 'enrol_oneroster') ] +
+        array_combine(
+            array_map(function($v){ return strval($v->id); }, $roles),
+            $roleNames
+        );
 
     // Mapping for the 'student' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'student', $allroles, $courseroles, 'student');

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,19 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(
+        new admin_setting_configselect(
+            'enrol_oneroster/shortname_attribute',
+            get_string('settings_shortname_attribute', 'enrol_oneroster'),
+            get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
+            'sourcedId',
+            [
+                'sourcedId' => 'sourcedId',
+                'classCode' => 'classCode'
+            ]
+        )
+    );
+
 
     // Role mappings for the following One Roster roles:
     // - student;

--- a/settings.php
+++ b/settings.php
@@ -174,6 +174,12 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    $settings->add(new admin_setting_heading(
+        'enrol_oneroster/attribute_mapping',
+        get_string('settings_attribute_mapping', 'enrol_oneroster'),
+        ''
+    ));
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',

--- a/settings.php
+++ b/settings.php
@@ -118,6 +118,16 @@ if ($ADMIN->fulltree) {
         4
     ));
 
+    $yesno = array(get_string('no'), get_string('yes'));
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_caching',
+        get_string('settings_connection_oneroster_caching', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_caching_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
+
     // Test connection.
     $settings->add(new admin_setting_heading(
         'enrol_oneroster/testconnection',

--- a/settings.php
+++ b/settings.php
@@ -264,6 +264,15 @@ if ($ADMIN->fulltree) {
     // Mapping for the 'relative' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'relative', $allroles, $courseroles);
 
+    $yesno = array(get_string('no'), get_string('yes'));
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_sync_agents',
+        get_string('settings_connection_oneroster_sync_agents', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_sync_agents_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
     // Data to synchronise:
     // - Fetch list of available schools button; and
     // - List of schools to sync.

--- a/settings.php
+++ b/settings.php
@@ -281,6 +281,24 @@ if ($ADMIN->fulltree) {
         $availableschools
     ));
 
+
+    $academic_sessions = [];
+    if ($academic_sessions_json = get_config('enrol_oneroster', 'academic_sessions')) {
+        $academic_sessions = (array) json_decode($academic_sessions_json);
+    }
+
+    if (empty($academic_sessions_json)) {
+        $academic_sessions[''] = get_string('none', 'admin');
+    }
+
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/datasync_academic_session',
+        get_string('settings_datasync_academic_session', 'enrol_oneroster'),
+        get_string('settings_datasync_academic_session_desc', 'enrol_oneroster'),
+        [],
+        $academic_sessions
+    ));
+
 }
 
 if ($hassiteconfig) {

--- a/settings.php
+++ b/settings.php
@@ -295,7 +295,7 @@ if ($ADMIN->fulltree) {
         'enrol_oneroster/datasync_academic_session',
         get_string('settings_datasync_academic_session', 'enrol_oneroster'),
         get_string('settings_datasync_academic_session_desc', 'enrol_oneroster'),
-        [],
+        '',
         $academic_sessions
     ));
 

--- a/settings.php
+++ b/settings.php
@@ -300,6 +300,14 @@ if ($ADMIN->fulltree) {
         $yesno
     ));
 
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_exclude_inactive',
+        get_string('settings_connection_oneroster_exclude_inactive', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_exclude_inactive_desc', 'enrol_oneroster'),
+        1,
+        $yesno
+    ));
+
     $settings->add(new admin_setting_configmultiselect(
         'enrol_oneroster/datasync_schools',
         get_string('settings_datasync_schools', 'enrol_oneroster'),

--- a/settings.php
+++ b/settings.php
@@ -205,6 +205,29 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    // User metadata.
+    $settings->add(new admin_setting_heading(
+        'enrol_oneroster/user_metadata',
+        new lang_string('settings_connection_oneroster_user_metadata', 'enrol_oneroster'),
+        new lang_string('settings_connection_oneroster_user_metadata_desc', 'enrol_oneroster')
+    ));
+
+    // User metadata - department.
+    $settings->add(new admin_setting_configtext(
+        'enrol_oneroster/user_department_map',
+        get_string('settings_connection_oneroster_user_department', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_user_department_desc', 'enrol_oneroster'),
+        ''
+    ));
+
+    // User metadata - department.
+    $settings->add(new admin_setting_configtext(
+        'enrol_oneroster/user_institution_map',
+        get_string('settings_connection_oneroster_user_institution', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_user_institution_desc', 'enrol_oneroster'),
+        ''
+    ));
+
 
     // Role mappings for the following One Roster roles:
     // - student;

--- a/settings.php
+++ b/settings.php
@@ -292,6 +292,14 @@ if ($ADMIN->fulltree) {
         $availableschools[''] = get_string('none', 'admin');
     }
 
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_sync_groups',
+        get_string('settings_connection_oneroster_sync_groups', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_sync_groups_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
     $settings->add(new admin_setting_configmultiselect(
         'enrol_oneroster/datasync_schools',
         get_string('settings_datasync_schools', 'enrol_oneroster'),

--- a/testconnection.php
+++ b/testconnection.php
@@ -67,10 +67,19 @@ $client->authenticate();
 $foundorgs = [];
 $organisations = $client->fetch_organisation_list();
 foreach ($organisations as $org) {
-    $foundorgs[$org->get('sourcedId')] = $org->get('name');
+    $foundorgs[$org->get('sourcedId')] = $org->get('name') . ' (' . $org->get('identifier') . ')' ;
 }
-
 set_config('availableschools', json_encode($foundorgs), 'enrol_oneroster');
+
+$academic_sessions = $client->fetch_academic_session_list();
+$found_sessions = [];
+foreach ($academic_sessions as $academic_session) {
+    // get only semesters
+    if ($academic_session->get('type') == 'semester') {
+        $found_sessions[$academic_session->get('sourcedId')] = $academic_session->get('title');
+    }
+}
+set_config('academic_sessions', json_encode($found_sessions), 'enrol_oneroster');
 
 redirect(
     $returnurl,

--- a/testconnection.php
+++ b/testconnection.php
@@ -75,7 +75,7 @@ $academic_sessions = $client->fetch_academic_session_list();
 $found_sessions = [];
 foreach ($academic_sessions as $academic_session) {
     // get only semesters
-    if ($academic_session->get('type') == 'semester') {
+    if ($academic_session->get('type') == 'semester' || $academic_session->get('type') == 'schoolYear') {
         $found_sessions[$academic_session->get('sourcedId')] = $academic_session->get('title');
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-07-21';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-07-21';
+$plugin->release = '2022-09-19';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2023031100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021012000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072100;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2021-01-20';
+$plugin->release = '2022-07-21';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102502;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-25';
+$plugin->release = '2024-10-29';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092002;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092601;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-20';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025010901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025011001;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-09';
+$plugin->release = '2025-01-10';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101403;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102001;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-14';
+$plugin->release = '2024-10-20';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101401;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101402;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-02';
+$plugin->release = '2024-10-14';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024041000;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024041000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091700;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-09-19';
+$plugin->release = '2024-09-17';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092601;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-20';
+$plugin->release = '2024-09-27';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-17';
+$plugin->release = '2024-09-19';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102501;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102502;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-10-25';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092002;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-19';
+$plugin->release = '2024-09-20';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-17';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102001;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102305;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-20';
+$plugin->release = '2024-10-23';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091700;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-17';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024092701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024100201;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-27';
+$plugin->release = '2024-10-02';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025010401;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025010901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-04';
-$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '2025-01-09';
+$plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024101402;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101403;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-10-14';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025010401;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-29';
+$plugin->release = '2025-01-04';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025011201;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025011703;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-12';
+$plugin->release = '2025-01-17';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024100201;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024101401;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-10-02';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025011001;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025011201;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-10';
+$plugin->release = '2025-01-12';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102305;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102501;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-23';
+$plugin->release = '2024-10-25';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025081901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025090902;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->supported = [
     405,
     500
 ];
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-08-19';
+$plugin->release = '2025-09-09';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025011703;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025012701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-17';
+$plugin->release = '2025-01-27';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025012901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025031801;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-29';
+$plugin->release = '2025-03-18';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025012701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025012901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-27';
+$plugin->release = '2025-01-29';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025031801;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025081901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
+$plugin->supported = [
+    405,
+    500
+];
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-03-18';
+$plugin->release = '2025-08-19';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR updates OneRoster client configuration to allow the usage of an school year as the active academic session. This operation is important when we are selecting to synchronize classes of a whole school year -including all semesters- or accepting web hooks for any semester of a specific school year.